### PR TITLE
Roll a specialized 1D interpolation and drop the scipy dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **.egg-info
 Animations/media/
 Tests/**.xml
+test-results-*.xml
 *.webm
 *.png
 *dist

--- a/Tests/test_interpolation.py
+++ b/Tests/test_interpolation.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from TerraFrame.Utilities import Interpolation
+import numpy as np
+
+
+def test_interpolation():
+    x = np.array([1, 2, 3])
+    y = np.array([1, 4, 9])
+
+    f = Interpolation.Interpolation1D(x, y)
+
+    xv = [0.5, 1.5, 2.0, 2.5, 3.0, 3.5]
+    yv = f(xv)
+
+    y_answer = [1.0, 2.5, 4.0, 6.5, 9.0, 9.0]
+
+    for i, v in enumerate(yv):
+        assert abs(v - y_answer[i]) < 1e-10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 
-dependencies = ["numpy", "scipy"]
+dependencies = ["numpy"]
 
 [project.optional-dependencies]
 dev = ["build", "twine", "setuptools"]

--- a/src/TerraFrame/Utilities/BulletinData.py
+++ b/src/TerraFrame/Utilities/BulletinData.py
@@ -8,7 +8,8 @@ from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
-from scipy.interpolate import interp1d
+
+from .Interpolation import Interpolation1D
 
 
 class BulletinData:
@@ -73,29 +74,17 @@ class BulletinData:
 
     def _init_interpolants(self):
         if BulletinData.f_pm_x is None:
-            BulletinData.f_pm_x = interp1d(self.data[:, 0], self.data[:, 2],
-                                           fill_value=(self.data[0, 1],
-                                                       self.data[-1, 1]),
-                                           bounds_error=False,
-                                           assume_sorted=True)
+            BulletinData.f_pm_x = Interpolation1D(self.data[:, 0],
+                                                  self.data[:, 2])
 
-            BulletinData.f_pm_y = interp1d(self.data[:, 0], self.data[:, 3],
-                                           fill_value=(self.data[0, 1],
-                                                       self.data[-1, 1]),
-                                           bounds_error=False,
-                                           assume_sorted=True)
+            BulletinData.f_pm_y = Interpolation1D(self.data[:, 0],
+                                                  self.data[:, 3])
 
-            BulletinData.f_nc_dx = interp1d(self.data[:, 0], self.data[:, 4],
-                                            fill_value=(self.data[0, 1],
-                                                        self.data[-1, 1]),
-                                            bounds_error=False,
-                                           assume_sorted=True)
+            BulletinData.f_nc_dx = Interpolation1D(self.data[:, 0],
+                                                   self.data[:, 4])
 
-            BulletinData.f_nc_dy = interp1d(self.data[:, 0], self.data[:, 5],
-                                            fill_value=(self.data[0, 1],
-                                                        self.data[-1, 1]),
-                                            bounds_error=False,
-                                           assume_sorted=True)
+            BulletinData.f_nc_dy = Interpolation1D(self.data[:, 0],
+                                                   self.data[:, 5])
 
     def _parse_file(self):
         # Don't reparse the file data
@@ -104,8 +93,8 @@ class BulletinData:
 
         file_content = []
 
-        with (resources.files("TerraFrame.Data").joinpath(self._file_name).open("r",
-                encoding="utf-8") as f):
+        with (resources.files("TerraFrame.Data").joinpath(self._file_name).open(
+                "r", encoding="utf-8") as f):
             file_content = f.readlines()
 
         data_tmp = []
@@ -152,7 +141,6 @@ class BulletinData:
 
                     # Nutation correction, dy (milliarcseconds)
                     line_data[5] = float(line[116:125])
-
 
                 data_tmp.append(line_data)
 

--- a/src/TerraFrame/Utilities/Interpolation.py
+++ b/src/TerraFrame/Utilities/Interpolation.py
@@ -1,0 +1,71 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import numpy as np
+from .Helpers import clamp, ensure_iterable
+
+
+class Interpolation1D:
+    """
+    This is not a general 1D interpolation class. It is specialized to the
+    specific usage requirements and patterns of TerraFrame.
+
+    Since most queries will be near each other, there is an index cache. If
+    the index is out of bounds, the first or last values are used.
+
+    """
+
+    def __init__(self, x, y):
+        self._x = x
+        self._y = y
+
+        self._index_cache = None
+
+    def _get_index(self, xv):
+        index = None
+
+        # Under nominal usage patterns, most queries will use the same index
+        # with only the occasional change
+        if self._index_cache is not None:
+            x1 = self._x[clamp(self._index_cache - 1, 0, len(self._x) - 1)]
+            x2 = self._x[clamp(self._index_cache, 0, len(self._x) - 1)]
+
+            if x1 < xv <= x2:
+                index = self._index_cache
+
+
+        if index is None:
+            index = np.searchsorted(self._x, xv)
+            self._index_cache = index
+
+        return index
+
+    def __call__(self, xv):
+        xv = ensure_iterable(xv)
+
+        yv = len(xv) * [0.0]
+
+        for i, v in enumerate(xv):
+            index = self._get_index(v)
+
+            # If we're out of bounds, return the first or last value
+            if index == 0:
+                yv[i] = self._y[index]
+                continue
+            elif index >= len(self._x):
+                yv[i] = self._y[-1]
+                continue
+
+            y2 = self._y[index]
+            y1 = self._y[index - 1]
+
+            x2 = self._x[index]
+            x1 = self._x[index - 1]
+
+            yv[i] = (y2 - y1) / (x2 - x1) * (xv[i] - x1) + y1
+
+        if len(yv) == 1:
+            return yv[0]
+        else:
+            return yv


### PR DESCRIPTION
The only reason we had scipy as a dependency was usage of interp1 in a single class. Scipy is relatively heavy for such limited usage. Additionally, since we should expect to notice appreciable performance gains from caching, it makes sense to roll our own interpolant using numpy as a base.